### PR TITLE
fix(gh-action):Change publish branch to master

### DIFF
--- a/.github/workflows/deploy-githubPages.yml
+++ b/.github/workflows/deploy-githubPages.yml
@@ -25,3 +25,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
+          publish_branch: master


### PR DESCRIPTION
BREAKING CHANGE: Publish branch changed to master instead using `gh-pages` branch